### PR TITLE
CSS style to inherit light and dark themes

### DIFF
--- a/stylesheet.css
+++ b/stylesheet.css
@@ -28,7 +28,9 @@
 }
 
 .menu-item-box {
-	background-color: #454c4c;
+	background-color: transparent;
+        box-shadow: 0px 1px 3px 1px rgba(0,0,0,0.5);
+        border: 2px solid rgba(90,105,111,0.5);
 	padding:6px;
 	border-radius: 4px;
 	spacing: 12px;
@@ -37,7 +39,8 @@
 
 .menu-item-box:hover,
 .menu-item-box:focus {
-	background-color: #5d6767;
+	background-color: transparent;
+        border: 2px solid #4690D9;
 }
 
 .account-group-label {


### PR DESCRIPTION
Hi @pulb 
##
#### Intro

I really appreciate your work on this extension its really handy, i currently help develop two extensions as well as the OSX-Arc theme collection, i thought as i use your extension i would contribute if its something you would like to merge.

1.  [Arc menu](https://github.com/LinxGem33/Arc-Menu)
2. [IP Finder](https://github.com/LinxGem33/IP-Finder) 
##
#### Pull-Request

This update allows the css to incorporate a modern stylised look which also inherits the light and dark elements of GTK 3 themes, in short this PR allows the user to easily switch between a light or dark theme without having to edit the css (also fixes bug #43 ) and also gives a modern look.
##
Signed-off-by: LinxGem33 - Andy C