### PR TITLE
stylesheet.css : updated stylesheet for gnome3.28 +

### DIFF
--- a/stylesheet.css
+++ b/stylesheet.css
@@ -29,6 +29,7 @@
 
 .menu-item-box {
 	background-color: rgba(255, 255, 255, 0.05);
+        border: 1px transparent;
 	padding:6px;
 	border-radius: 4px;
 	spacing: 12px;
@@ -38,10 +39,11 @@
 .menu-item-box:hover,
 .menu-item-box:focus {
 	background-color: rgba(255, 255, 255, 0.12);
+        border: 1px solid #5294E2;
 }
 
 .account-group-label {
-	color: #8e8e80;
+	color: #5294E2;
 	font-size: medium;
 	font-weight: bold;
 }
@@ -71,8 +73,7 @@
 }
 
 .overflow-badge {
-	color: #393f3f;
-	background-color: #59594f; /*#8e8e80;*/
+        border: 1px #5294E2;
 	font-size: small;
 	padding: 0em 0.4em 0em 0.4em;
 	border-radius: 4px;


### PR DESCRIPTION
Hi @pulb  apologies for the delay in this pull-request

The following pull-request ;

Updates the stylesheet for gnome 3.18 + for better integration with light and dark themes, also ive updated the areas you suggested before i.e `.account-group-label {` and i left the more-label, date-label  as they should fit with the overall styling ive also updated the `.overflow-badge {` so the groups mail count now follows the styling, overall I've followed as close to the gnome styling for better integration with the gnome-shell.